### PR TITLE
Add projects page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { Routes, Route } from "react-router";
+import Projects from "./pages/Projects";
 
 function App() {
   return (
@@ -11,6 +12,7 @@ function App() {
           </div>
         }
       />
+      <Route path="/projects" element={<Projects />} />
     </Routes>
   );
 }

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { useProjectStore } from "../store/useProjectStore";
+
+function Projects() {
+  const { projects, currentProject, addProject, deleteProject, setProject } =
+    useProjectStore();
+
+  const [title, setTitle] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    addProject({
+      id: crypto.randomUUID(),
+      title,
+      startDate,
+      endDate,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    setTitle("");
+    setStartDate("");
+    setEndDate("");
+  };
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold">Projets</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          className="w-full border p-2"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Titre"
+          required
+        />
+        <input
+          type="date"
+          className="w-full border p-2"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          required
+        />
+        <input
+          type="date"
+          className="w-full border p-2"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          required
+        />
+        <button type="submit" className="bg-blue-500 px-4 py-2 text-white">
+          Ajouter
+        </button>
+      </form>
+      <ul className="space-y-2">
+        {projects.map((project) => (
+          <li key={project.id} className="flex justify-between border p-2">
+            <button
+              type="button"
+              onClick={() => setProject(project)}
+              className="text-left"
+            >
+              <div className="font-semibold">{project.title}</div>
+              <div className="text-sm text-gray-600">
+                {project.startDate} – {project.endDate}
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => deleteProject(project.id)}
+              className="text-red-500"
+            >
+              Supprimer
+            </button>
+          </li>
+        ))}
+      </ul>
+      {currentProject && (
+        <div className="text-green-600">
+          Projet sélectionné : {currentProject.title}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Projects;

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -2,11 +2,23 @@ import { create } from "zustand";
 import type { Project } from "../types/project";
 
 type ProjectStore = {
+  projects: Project[];
   currentProject: Project | null;
+  addProject: (project: Project) => void;
+  deleteProject: (id: string) => void;
   setProject: (project: Project) => void;
 };
 
 export const useProjectStore = create<ProjectStore>((set) => ({
+  projects: [],
   currentProject: null,
+  addProject: (project) =>
+    set((state) => ({ projects: [...state.projects, project] })),
+  deleteProject: (id) =>
+    set((state) => ({
+      projects: state.projects.filter((p) => p.id !== id),
+      currentProject:
+        state.currentProject?.id === id ? null : state.currentProject,
+    })),
   setProject: (project) => set({ currentProject: project }),
 }));

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,6 +1,8 @@
 export interface Project {
   id: string;
   title: string;
+  startDate: string;
+  endDate: string;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- define project start and end dates
- expand project store with list, add and delete
- add new page to manage projects
- include projects page in router

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6888c11f33788325a0caf7f0623c7bdd