### PR TITLE
Add project JSON import/export

### DIFF
--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,0 +1,15 @@
+import type { Project } from "../types/project";
+
+export function exportProjectJSON(project: Project): string {
+  return JSON.stringify(project, null, 2);
+}
+
+export function importProjectJSON(json: string): Project {
+  return JSON.parse(json) as Project;
+}
+
+// Placeholder for future JSZip integration
+export async function exportProjectZIP(project: Project): Promise<Blob> {
+  void project; // placeholder to avoid unused parameter lint error
+  throw new Error("JSZip integration not implemented");
+}

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useProjectStore } from "../store/useProjectStore";
+import { importProjectJSON } from "../lib/export";
 
 function Projects() {
   const { projects, currentProject, addProject, deleteProject, setProject } =
@@ -22,6 +23,17 @@ function Projects() {
     setTitle("");
     setStartDate("");
     setEndDate("");
+  };
+
+  const handleImport = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ): Promise<void> => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const json = await file.text();
+    const project = importProjectJSON(json);
+    addProject(project);
+    e.target.value = "";
   };
 
   return (
@@ -52,6 +64,12 @@ function Projects() {
         <button type="submit" className="bg-blue-500 px-4 py-2 text-white">
           Ajouter
         </button>
+        <input
+          type="file"
+          accept="application/json"
+          onChange={handleImport}
+          className="w-full"
+        />
       </form>
       <ul className="space-y-2">
         {projects.map((project) => (

--- a/src/types/jszip.d.ts
+++ b/src/types/jszip.d.ts
@@ -1,0 +1,8 @@
+declare module "jszip" {
+  class JSZip {
+    file(name: string, data: string | Blob): this;
+    generateAsync(options: { type: string }): Promise<Blob>;
+  }
+
+  export default JSZip;
+}


### PR DESCRIPTION
## Summary
- add `export.ts` module for JSON export/import with placeholder for JSZip
- allow importing project JSON files from the projects page
- define temporary JSZip typings for future ZIP export

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6888c79694f48325a0642bb1d7e6d950