### PR TITLE
Add group participant management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route } from "react-router";
 import Sidebar from "./components/Sidebar";
 import Projects from "./pages/Projects";
+import Groupement from "./pages/Groupement";
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
             }
           />
           <Route path="/projects" element={<Projects />} />
+          <Route path="/groupement" element={<Groupement />} />
         </Routes>
       </div>
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,6 +21,14 @@ function Sidebar() {
       >
         Projets
       </NavLink>
+      <NavLink
+        to="/groupement"
+        className={({ isActive }) =>
+          `mb-2 rounded px-2 py-1 ${isActive ? "bg-blue-500 text-white" : "text-blue-500"}`
+        }
+      >
+        Groupement
+      </NavLink>
     </nav>
   );
 }

--- a/src/pages/Groupement.tsx
+++ b/src/pages/Groupement.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { useProjectStore } from "../store/useProjectStore";
+import type { GroupMember } from "../types/project";
+
+function Groupement() {
+  const { currentProject, updateCurrentProject } = useProjectStore();
+  const [name, setName] = useState("");
+
+  if (!currentProject) {
+    return (
+      <div className="p-4 text-red-500">Veuillez sélectionner un projet.</div>
+    );
+  }
+
+  const members = currentProject.groupMembers ?? [];
+
+  const handleAdd = () => {
+    if (!name.trim()) return;
+    const newMember: GroupMember = { id: crypto.randomUUID(), name };
+    updateCurrentProject({ groupMembers: [...members, newMember] });
+    setName("");
+  };
+
+  const handleDelete = (id: string) => {
+    updateCurrentProject({
+      groupMembers: members.filter((m) => m.id !== id),
+      mandataireId:
+        currentProject.mandataireId === id
+          ? undefined
+          : currentProject.mandataireId,
+    });
+  };
+
+  const handleMandataire = (id: string) => {
+    updateCurrentProject({ mandataireId: id });
+  };
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold">Groupement</h1>
+      <label className="block font-semibold">Type de groupement</label>
+      <select
+        className="w-full border p-2"
+        value={currentProject.groupType ?? ""}
+        onChange={(e) =>
+          updateCurrentProject({
+            groupType: e.target.value as "solidaire" | "conjoint",
+          })
+        }
+      >
+        <option value="">-- choisir --</option>
+        <option value="solidaire">Solidaire</option>
+        <option value="conjoint">Conjoint</option>
+      </select>
+
+      <div className="space-y-2">
+        <label className="block font-semibold">Participants</label>
+        <div className="flex space-x-2">
+          <input
+            className="flex-1 border p-2"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Nom de l'entreprise"
+          />
+          <button
+            type="button"
+            onClick={handleAdd}
+            className="bg-blue-500 px-4 py-2 text-white"
+          >
+            Ajouter
+          </button>
+        </div>
+        <ul className="space-y-1">
+          {members.map((member) => (
+            <li key={member.id} className="flex items-center justify-between">
+              <label className="flex items-center space-x-2">
+                <input
+                  type="radio"
+                  name="mandataire"
+                  checked={currentProject.mandataireId === member.id}
+                  onChange={() => handleMandataire(member.id)}
+                />
+                <span>{member.name}</span>
+              </label>
+              <button
+                type="button"
+                onClick={() => handleDelete(member.id)}
+                className="text-red-500"
+              >
+                Supprimer
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default Groupement;

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -12,6 +12,7 @@ type ProjectStore = {
   addProject: (project: Project) => void;
   deleteProject: (id: string) => void;
   setProject: (project: Project) => void;
+  updateCurrentProject: (data: Partial<Project>) => void;
 };
 
 export const useProjectStore = create<ProjectStore>((set) => {
@@ -34,5 +35,22 @@ export const useProjectStore = create<ProjectStore>((set) => {
       void removeProject(id);
     },
     setProject: (project) => set({ currentProject: project }),
+    updateCurrentProject: (data) => {
+      set((state) => {
+        if (!state.currentProject) return state;
+        const updated = {
+          ...state.currentProject,
+          ...data,
+          updatedAt: new Date().toISOString(),
+        };
+        void persistProject(updated);
+        return {
+          projects: state.projects.map((p) =>
+            p.id === updated.id ? updated : p,
+          ),
+          currentProject: updated,
+        };
+      });
+    },
   };
 });

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,3 +1,8 @@
+export interface GroupMember {
+  id: string;
+  name: string;
+}
+
 export interface Project {
   id: string;
   title: string;
@@ -5,4 +10,7 @@ export interface Project {
   endDate: string;
   createdAt: string;
   updatedAt: string;
+  groupType?: "solidaire" | "conjoint";
+  groupMembers?: GroupMember[];
+  mandataireId?: string;
 }


### PR DESCRIPTION
## Summary
- manage group participants in project state
- add Groupement page
- link Groupement in sidebar and router

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6888ced434dc8325a450f0f0e1558b2a