### PR TITLE
Add mobilized people management

### DIFF
--- a/src/components/MobilizedPeopleList.tsx
+++ b/src/components/MobilizedPeopleList.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import type { MobilizedPerson, ParticipatingCompany } from "../types/project";
+
+interface MobilizedPeopleListProps {
+  company: ParticipatingCompany;
+  onFileChange: (companyId: string, personId: string, file?: File) => void;
+  onSummarize: (companyId: string, personId: string) => void;
+  onUpdate: (people: MobilizedPerson[]) => void;
+}
+
+function MobilizedPeopleList({
+  company,
+  onFileChange,
+  onSummarize,
+  onUpdate,
+}: MobilizedPeopleListProps) {
+  const [personName, setPersonName] = useState("");
+  const people = company.mobilizedPeople ?? [];
+
+  const handleAdd = () => {
+    if (!personName.trim()) return;
+    const newPerson: MobilizedPerson = {
+      id: crypto.randomUUID(),
+      name: personName,
+    };
+    onUpdate([...people, newPerson]);
+    setPersonName("");
+  };
+
+  const handleDelete = (id: string) => {
+    onUpdate(people.filter((p) => p.id !== id));
+  };
+
+  return (
+    <div className="space-y-2 border-t pt-2">
+      <label className="font-semibold">Personnes mobilisées</label>
+      <div className="flex space-x-2">
+        <input
+          className="flex-1 border p-1"
+          value={personName}
+          onChange={(e) => setPersonName(e.target.value)}
+          placeholder="Nom de la personne"
+        />
+        <button
+          type="button"
+          onClick={handleAdd}
+          className="bg-blue-500 px-2 text-white"
+        >
+          Ajouter
+        </button>
+      </div>
+      <ul className="space-y-1">
+        {people.map((person) => (
+          <li key={person.id} className="space-y-1 rounded border p-2">
+            <div className="flex items-center justify-between">
+              <span>{person.name}</span>
+              <button
+                type="button"
+                onClick={() => handleDelete(person.id)}
+                className="text-red-500"
+              >
+                Supprimer
+              </button>
+            </div>
+            <div className="flex space-x-2">
+              <input
+                type="file"
+                accept="application/pdf"
+                onChange={(e) =>
+                  onFileChange(company.id, person.id, e.target.files?.[0])
+                }
+              />
+              <button
+                type="button"
+                onClick={() => onSummarize(company.id, person.id)}
+                className="bg-green-500 px-2 text-white"
+              >
+                Résumer
+              </button>
+            </div>
+            {person.cvSummary && (
+              <textarea
+                className="mt-2 w-full border p-2"
+                readOnly
+                value={person.cvSummary}
+              />
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default MobilizedPeopleList;

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,9 +1,16 @@
-export interface GroupMember {
+export interface MobilizedPerson {
   id: string;
   name: string;
-  dailyRate?: number;
   cvText?: string;
   cvSummary?: string;
+}
+
+export interface ParticipatingCompany {
+  id: string;
+  name: string;
+  presentationText?: string;
+  presentationSummary?: string;
+  mobilizedPeople?: MobilizedPerson[];
 }
 
 export interface Project {
@@ -14,6 +21,6 @@ export interface Project {
   createdAt: string;
   updatedAt: string;
   groupType?: "solidaire" | "conjoint";
-  groupMembers?: GroupMember[];
+  participatingCompanies?: ParticipatingCompany[];
   mandataireId?: string;
 }


### PR DESCRIPTION
## Summary
- rename group members to participating companies and support mobilized people
- collect company presentation and CVs for mobilized people
- add MobilizedPeopleList component

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6888d59dc8588325b57b603521e8ad3c