### PR TITLE
Add daily rate field for mobilized people

### DIFF
--- a/src/components/MobilizedPeopleList.tsx
+++ b/src/components/MobilizedPeopleList.tsx
@@ -15,6 +15,7 @@ function MobilizedPeopleList({
   onUpdate,
 }: MobilizedPeopleListProps) {
   const [personName, setPersonName] = useState("");
+  const [dailyRate, setDailyRate] = useState(0);
   const people = company.mobilizedPeople ?? [];
 
   const handleAdd = () => {
@@ -22,9 +23,11 @@ function MobilizedPeopleList({
     const newPerson: MobilizedPerson = {
       id: crypto.randomUUID(),
       name: personName,
+      dailyRate,
     };
     onUpdate([...people, newPerson]);
     setPersonName("");
+    setDailyRate(0);
   };
 
   const handleDelete = (id: string) => {
@@ -41,6 +44,13 @@ function MobilizedPeopleList({
           onChange={(e) => setPersonName(e.target.value)}
           placeholder="Nom de la personne"
         />
+        <input
+          type="number"
+          className="w-24 border p-1"
+          value={dailyRate}
+          onChange={(e) => setDailyRate(Number(e.target.value))}
+          placeholder="Taux HT"
+        />
         <button
           type="button"
           onClick={handleAdd}
@@ -54,13 +64,29 @@ function MobilizedPeopleList({
           <li key={person.id} className="space-y-1 rounded border p-2">
             <div className="flex items-center justify-between">
               <span>{person.name}</span>
-              <button
-                type="button"
-                onClick={() => handleDelete(person.id)}
-                className="text-red-500"
-              >
-                Supprimer
-              </button>
+              <div className="flex items-center space-x-2">
+                <input
+                  type="number"
+                  className="w-24 border p-1"
+                  value={person.dailyRate ?? 0}
+                  onChange={(e) =>
+                    onUpdate(
+                      people.map((p) =>
+                        p.id === person.id
+                          ? { ...p, dailyRate: Number(e.target.value) }
+                          : p,
+                      ),
+                    )
+                  }
+                />
+                <button
+                  type="button"
+                  onClick={() => handleDelete(person.id)}
+                  className="text-red-500"
+                >
+                  Supprimer
+                </button>
+              </div>
             </div>
             <div className="flex space-x-2">
               <input

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,6 +1,10 @@
 import OpenAI from "openai";
 
 import * as pdfjsLib from "pdfjs-dist";
+import type {
+  TextItem,
+  TextMarkedContent,
+} from "pdfjs-dist/types/src/display/api";
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = "/memoire-technique/pdf.worker.mjs";
 
@@ -16,7 +20,9 @@ export async function extractTextFromPdf(file: File): Promise<string> {
   for (let i = 1; i <= pdf.numPages; i++) {
     const page = await pdf.getPage(i);
     const content = await page.getTextContent();
-    const strings = content.items.map((item: any) => item.str);
+    const strings = (content.items as Array<TextItem | TextMarkedContent>)
+      .filter((item): item is TextItem => "str" in item)
+      .map((item) => item.str);
     text += strings.join(" ") + "\n";
   }
 
@@ -43,7 +49,7 @@ export async function summarize(
     ],
   });
 
-  return completion.choices[0].message.content.trim();
+  return completion.choices[0].message.content?.trim() ?? "";
 }
 
 export async function testKey(apiKey: string): Promise<boolean> {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,6 +1,8 @@
 export interface MobilizedPerson {
   id: string;
   name: string;
+  /** Taux journalier hors taxes en euros */
+  dailyRate?: number;
   cvFile?: string;
   cvText?: string;
   cvSummary?: string;


### PR DESCRIPTION
## Summary
- add `dailyRate` to mobilized people type
- allow entering daily rate when adding a mobilized person
- let daily rate be editable in the list
- fix lint in OpenAI helper

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6889d9e474048325ae19fe32081ff8fb