### PR TITLE
Add mémoire technique page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from "react-router";
 import Sidebar from "./components/Sidebar";
 import Projects from "./pages/Projects";
 import Groupement from "./pages/Groupement";
+import Memoire from "./pages/Memoire";
 import Settings from "./pages/Settings";
 
 function App() {
@@ -20,6 +21,7 @@ function App() {
           />
           <Route path="/projects" element={<Projects />} />
           <Route path="/groupement" element={<Groupement />} />
+          <Route path="/memoire" element={<Memoire />} />
           <Route path="/parametres" element={<Settings />} />
         </Routes>
       </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -30,6 +30,14 @@ function Sidebar() {
         Groupement
       </NavLink>
       <NavLink
+        to="/memoire"
+        className={({ isActive }) =>
+          `mb-2 rounded px-2 py-1 ${isActive ? "bg-blue-500 text-white" : "text-blue-500"}`
+        }
+      >
+        Mémoire
+      </NavLink>
+      <NavLink
         to="/parametres"
         className={({ isActive }) =>
           `mb-2 rounded px-2 py-1 ${isActive ? "bg-blue-500 text-white" : "text-blue-500"}`

--- a/src/pages/Memoire.tsx
+++ b/src/pages/Memoire.tsx
@@ -1,0 +1,23 @@
+import { useProjectStore } from "../store/useProjectStore";
+
+function Memoire() {
+  const { currentProject } = useProjectStore();
+
+  if (!currentProject) {
+    return (
+      <div className="p-4 text-red-500">Veuillez sélectionner un projet.</div>
+    );
+  }
+
+  return (
+    <div className="prose mx-auto p-4">
+      {currentProject.memoHtml ? (
+        <div dangerouslySetInnerHTML={{ __html: currentProject.memoHtml }} />
+      ) : (
+        <div>Aucun mémoire technique disponible.</div>
+      )}
+    </div>
+  );
+}
+
+export default Memoire;

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -25,4 +25,6 @@ export interface Project {
   groupType?: "solidaire" | "conjoint";
   participatingCompanies?: ParticipatingCompany[];
   mandataireId?: string;
+  /** Contenu HTML du mémoire technique généré */
+  memoHtml?: string;
 }


### PR DESCRIPTION
## Summary
- show HTML mémoire technique for current project
- link the new page in the sidebar and router
- extend Project type to store memoHtml

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6889f36e84608325b03bc2fe527fe9e5