### PR TITLE
Add market document upload page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from "react-router";
 import Sidebar from "./components/Sidebar";
 import Projects from "./pages/Projects";
 import Groupement from "./pages/Groupement";
+import MarketDocs from "./pages/MarketDocs";
 import Memoire from "./pages/Memoire";
 import Settings from "./pages/Settings";
 
@@ -21,6 +22,7 @@ function App() {
           />
           <Route path="/projects" element={<Projects />} />
           <Route path="/groupement" element={<Groupement />} />
+          <Route path="/documents" element={<MarketDocs />} />
           <Route path="/memoire" element={<Memoire />} />
           <Route path="/parametres" element={<Settings />} />
         </Routes>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -30,6 +30,14 @@ function Sidebar() {
         Groupement
       </NavLink>
       <NavLink
+        to="/documents"
+        className={({ isActive }) =>
+          `mb-2 rounded px-2 py-1 ${isActive ? "bg-blue-500 text-white" : "text-blue-500"}`
+        }
+      >
+        Pièces marché
+      </NavLink>
+      <NavLink
         to="/memoire"
         className={({ isActive }) =>
           `mb-2 rounded px-2 py-1 ${isActive ? "bg-blue-500 text-white" : "text-blue-500"}`

--- a/src/pages/MarketDocs.tsx
+++ b/src/pages/MarketDocs.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import { useProjectStore } from "../store/useProjectStore";
+import { extractPdfText } from "../lib/pdf";
+import { extractDocxText } from "../lib/docx";
+import type { MarketDocument, MarketDocumentType } from "../types/project";
+
+function MarketDocs() {
+  const { currentProject, updateCurrentProject } = useProjectStore();
+  const [docType, setDocType] = useState<MarketDocumentType>("RC");
+
+  if (!currentProject) {
+    return (
+      <div className="p-4 text-red-500">Veuillez sélectionner un projet.</div>
+    );
+  }
+
+  const docs = currentProject.marketDocuments ?? [];
+
+  const handleFileChange = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ): Promise<void> => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = file.name.toLowerCase().endsWith(".docx")
+      ? await extractDocxText(file)
+      : await extractPdfText(file);
+    const doc: MarketDocument = {
+      id: crypto.randomUUID(),
+      name: file.name,
+      type: docType,
+      text,
+    };
+    updateCurrentProject({ marketDocuments: [...docs, doc] });
+    setDocType("RC");
+    e.target.value = "";
+  };
+
+  const handleDelete = (id: string): void => {
+    updateCurrentProject({ marketDocuments: docs.filter((d) => d.id !== id) });
+  };
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold">Pièces de marché</h1>
+      <div className="flex gap-2">
+        <select
+          className="border p-2"
+          value={docType}
+          onChange={(e) => setDocType(e.target.value as MarketDocumentType)}
+        >
+          <option value="RC">RC</option>
+          <option value="CCTP">CCTP</option>
+          <option value="CCAP">CCAP</option>
+          <option value="AE">AE</option>
+          <option value="AUTRE">Autre</option>
+        </select>
+        <input type="file" accept=".pdf,.docx" onChange={handleFileChange} />
+      </div>
+      <ul className="space-y-2">
+        {docs.map((doc) => (
+          <li key={doc.id} className="space-y-1 border p-2">
+            <div className="flex justify-between">
+              <div className="font-semibold">
+                {doc.name} ({doc.type})
+              </div>
+              <button
+                type="button"
+                onClick={() => handleDelete(doc.id)}
+                className="text-red-500"
+              >
+                Supprimer
+              </button>
+            </div>
+            <textarea className="w-full border p-2" readOnly value={doc.text} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default MarketDocs;

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -15,6 +15,15 @@ export interface ParticipatingCompany {
   mobilizedPeople?: MobilizedPerson[];
 }
 
+export type MarketDocumentType = "RC" | "CCTP" | "CCAP" | "AE" | "AUTRE";
+
+export interface MarketDocument {
+  id: string;
+  name: string;
+  type: MarketDocumentType;
+  text: string;
+}
+
 export interface Project {
   id: string;
   title: string;
@@ -25,6 +34,7 @@ export interface Project {
   groupType?: "solidaire" | "conjoint";
   participatingCompanies?: ParticipatingCompany[];
   mandataireId?: string;
+  marketDocuments?: MarketDocument[];
   /** Contenu HTML du mémoire technique généré */
   memoHtml?: string;
 }


### PR DESCRIPTION
## Summary
- add `MarketDocs` page for PDF/DOCX uploads
- store uploaded text in projects
- route `/documents` for the new page
- link to the new page from Sidebar
- extend `Project` type with market document info

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6889fc75d4d88325a8b28e4d0311d2b4