### PR TITLE
Remove project date range

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -7,13 +7,23 @@ const store = localforage.createInstance({ name: "projects" });
 export async function loadProjects(): Promise<Project[]> {
   const projects: Project[] = [];
   await store.iterate<Project, void>((value) => {
-    projects.push(stripPdfFields(value));
+    const obj = value as unknown as Record<string, string>;
+    const normalized = {
+      ...value,
+      creationDate: obj.creationDate ?? obj.createdAt,
+      lastUpdateDate: obj.lastUpdateDate ?? obj.updatedAt,
+    } as Project;
+    projects.push(stripPdfFields(normalized));
   });
   return projects;
 }
 
 export function saveProject(project: Project): Promise<void> {
-  return store.setItem(project.id, stripPdfFields(project)).then(() => {});
+  const updated = {
+    ...project,
+    lastUpdateDate: new Date().toISOString(),
+  } satisfies Project;
+  return store.setItem(updated.id, stripPdfFields(updated)).then(() => {});
 }
 
 export function deleteProject(id: string): Promise<void> {

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -14,22 +14,16 @@ function Projects() {
     useProjectStore();
 
   const [title, setTitle] = useState("");
-  const [startDate, setStartDate] = useState("");
-  const [endDate, setEndDate] = useState("");
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     addProject({
       id: crypto.randomUUID(),
       title,
-      startDate,
-      endDate,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+      creationDate: new Date().toISOString(),
+      lastUpdateDate: new Date().toISOString(),
     });
     setTitle("");
-    setStartDate("");
-    setEndDate("");
   };
 
   const handleImport = async (
@@ -70,20 +64,6 @@ function Projects() {
           placeholder="Titre"
           required
         />
-        <input
-          type="date"
-          className="w-full border p-2"
-          value={startDate}
-          onChange={(e) => setStartDate(e.target.value)}
-          required
-        />
-        <input
-          type="date"
-          className="w-full border p-2"
-          value={endDate}
-          onChange={(e) => setEndDate(e.target.value)}
-          required
-        />
         <button
           type="submit"
           className="cursor-pointer bg-blue-500 px-4 py-2 text-white"
@@ -108,7 +88,10 @@ function Projects() {
               >
                 <div className="font-semibold">{project.title}</div>
                 <div className="text-sm text-gray-600">
-                  {project.startDate} – {project.endDate}
+                  Créé le {project.creationDate}
+                </div>
+                <div className="text-sm text-gray-600">
+                  Modifié le {project.lastUpdateDate}
                 </div>
               </button>
               <button

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -63,7 +63,7 @@ export const useProjectStore = create<ProjectStore>((set) => {
         const updated = stripPdfFields({
           ...state.currentProject,
           ...data,
-          updatedAt: new Date().toISOString(),
+          lastUpdateDate: new Date().toISOString(),
         });
         void persistProject(updated);
         return {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -32,10 +32,8 @@ export interface NotationItem {
 export interface Project {
   id: string;
   title: string;
-  startDate: string;
-  endDate: string;
-  createdAt: string;
-  updatedAt: string;
+  creationDate: string;
+  lastUpdateDate: string;
   groupType?: "solidaire" | "conjoint";
   participatingCompanies?: ParticipatingCompany[];
   mandataireId?: string;


### PR DESCRIPTION
## Summary
- drop startDate and endDate fields from project interface
- keep creationDate and lastUpdateDate for each project
- update project list UI accordingly
- auto-update lastUpdateDate on every persistence

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_688a2a15fb448325a0107702665249fb