### PR TITLE
feat: analyse AE to list missions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Sidebar from "./components/Sidebar";
 import Projects from "./pages/Projects";
 import Groupement from "./pages/Groupement";
 import MarketDocs from "./pages/MarketDocs";
+import Missions from "./pages/Missions";
 import Memoire from "./pages/Memoire";
 import Notation from "./pages/Notation";
 import Settings from "./pages/Settings";
@@ -25,6 +26,7 @@ function App() {
           <Route path="/groupement" element={<Groupement />} />
           <Route path="/documents" element={<MarketDocs />} />
           <Route path="/memoire" element={<Memoire />} />
+          <Route path="/missions" element={<Missions />} />
           <Route path="/notation" element={<Notation />} />
           <Route path="/parametres" element={<Settings />} />
         </Routes>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -46,6 +46,14 @@ function Sidebar() {
         Mémoire
       </NavLink>
       <NavLink
+        to="/missions"
+        className={({ isActive }) =>
+          `mb-2 rounded px-2 py-1 ${isActive ? "bg-blue-500 text-white" : "text-blue-500"}`
+        }
+      >
+        Missions
+      </NavLink>
+      <NavLink
         to="/notation"
         className={({ isActive }) =>
           `mb-2 rounded px-2 py-1 ${isActive ? "bg-blue-500 text-white" : "text-blue-500"}`

--- a/src/lib/OpenAI/extractMissions.ts
+++ b/src/lib/OpenAI/extractMissions.ts
@@ -1,0 +1,30 @@
+import createClient from "./client";
+
+export default async function extractMissions(
+  text: string,
+  apiKey: string,
+): Promise<string[]> {
+  const openai = createClient(apiKey);
+  const truncated = text.slice(0, 100000);
+  const chat = await openai.chat.completions.create({
+    model: "gpt-4o",
+    messages: [
+      {
+        role: "system",
+        content: `Tu es un expert en analyse d'actes d'engagement. D\u00e9duis la liste des missions demand\u00e9es et r\u00e9ponds uniquement en JSON au format {"missions": ["mission 1", "mission 2"]}`,
+      },
+      {
+        role: "user",
+        content: truncated,
+      },
+    ],
+    response_format: { type: "json_object" },
+  });
+  const content = chat.choices[0].message.content ?? "{}";
+  try {
+    return JSON.parse(content).missions as string[];
+  } catch {
+    console.error("Erreur de parsing JSON", content);
+    return [];
+  }
+}

--- a/src/lib/OpenAI/index.ts
+++ b/src/lib/OpenAI/index.ts
@@ -5,3 +5,4 @@ export { default as extractMethodologyScores } from "./extractMethodologyScores"
 export type { MethodologyScore } from "./extractMethodologyScores";
 export { default as extractConsultationInfo } from "./extractConsultationInfo";
 export type { ConsultationInfo } from "./extractConsultationInfo";
+export { default as extractMissions } from "./extractMissions";

--- a/src/pages/MarketDocs.tsx
+++ b/src/pages/MarketDocs.tsx
@@ -3,7 +3,7 @@ import { useProjectStore } from "../store/useProjectStore";
 import { useOpenAIKeyStore } from "../store/useOpenAIKeyStore";
 import { extractPdfText } from "../lib/pdf";
 import { extractDocxText } from "../lib/docx";
-import { extractMethodologyScores } from "../lib/OpenAI";
+import { extractMethodologyScores, extractMissions } from "../lib/OpenAI";
 import type { MarketDocument, MarketDocumentType } from "../types/project";
 
 function MarketDocs() {
@@ -34,6 +34,14 @@ function MarketDocs() {
       text,
     };
     updateCurrentProject({ marketDocuments: [...docs, doc] });
+    if (docType === "AE" && apiKey) {
+      try {
+        const missions = await extractMissions(text, apiKey);
+        updateCurrentProject({ missions });
+      } catch (err) {
+        console.error(err);
+      }
+    }
     if (docType === "RC" && apiKey) {
       try {
         const notation = await extractMethodologyScores(text, apiKey);

--- a/src/pages/Missions.tsx
+++ b/src/pages/Missions.tsx
@@ -1,0 +1,30 @@
+import { useProjectStore } from "../store/useProjectStore";
+
+function Missions() {
+  const { currentProject } = useProjectStore();
+
+  if (!currentProject) {
+    return (
+      <div className="p-4 text-red-500">Veuillez sélectionner un projet.</div>
+    );
+  }
+
+  const missions = currentProject.missions ?? [];
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold">Missions</h1>
+      {missions.length ? (
+        <ul className="list-disc pl-6">
+          {missions.map((mission, idx) => (
+            <li key={idx}>{mission}</li>
+          ))}
+        </ul>
+      ) : (
+        <div>Aucune mission détectée.</div>
+      )}
+    </div>
+  );
+}
+
+export default Missions;

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -45,4 +45,6 @@ export interface Project {
   memoHtml?: string;
   /** Barème de la note méthodologique extrait du RC */
   notation?: NotationItem[];
+  /** Missions demandées dans l'acte d'engagement */
+  missions?: string[];
 }


### PR DESCRIPTION
## Summary
- add missions extraction from AE with OpenAI
- display missions on a new page
- wire new page into router and sidebar

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_688a37ebf244832588e0b0c77b189a06