### PR TITLE
feat: calculate mission costs

### DIFF
--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -29,6 +29,11 @@ export interface NotationItem {
   points: number;
 }
 
+export type MissionDays = Record<
+  string,
+  Record<string, Record<string, number>>
+>;
+
 export interface Project {
   id: string;
   /** Titre de la consultation extrait du RC */
@@ -47,4 +52,6 @@ export interface Project {
   notation?: NotationItem[];
   /** Missions demandées dans l'acte d'engagement */
   missions?: string[];
+  /** Jours alloués par mission, entreprise et personne mobilisée */
+  missionDays?: MissionDays;
 }


### PR DESCRIPTION
## Summary
- track days per participant per mission
- display cost breakdown per mission

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_688a3b0e00108325b4298a90f6e9cc14