### PR TITLE
Implement TUJ check on mission costs

### DIFF
--- a/src/pages/Missions.tsx
+++ b/src/pages/Missions.tsx
@@ -16,6 +16,21 @@ function Missions() {
 
   const missions = currentProject.missions ?? [];
   const companies = currentProject.participatingCompanies ?? [];
+  const missingRates = companies.flatMap((company) =>
+    (company.mobilizedPeople ?? []).filter((p) => !p.dailyRate),
+  );
+
+  if (missingRates.length) {
+    return (
+      <div className="space-y-2 p-4 text-red-500">
+        {missingRates.map((p) => (
+          <div key={p.id}>
+            Aller dans la page Groupement pour indiquer un TUJ pour {p.name}
+          </div>
+        ))}
+      </div>
+    );
+  }
   const missionDays: MissionDays = currentProject.missionDays ?? {};
 
   const getDays = (


### PR DESCRIPTION
## Summary
- if any team member has a daily rate of 0 on the Missions page, show an error message and skip calculations

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_688a442b167883258ade4699f8a9ece2