### PR TITLE
Extract works amount from AE

### DIFF
--- a/src/lib/OpenAI/extractWorksAmount.ts
+++ b/src/lib/OpenAI/extractWorksAmount.ts
@@ -1,0 +1,31 @@
+import createClient from "./client";
+
+export default async function extractWorksAmount(
+  text: string,
+  apiKey: string,
+): Promise<number | undefined> {
+  const openai = createClient(apiKey);
+  const truncated = text.slice(0, 100000);
+  const chat = await openai.chat.completions.create({
+    model: "gpt-4o",
+    messages: [
+      {
+        role: "system",
+        content:
+          "Tu es un expert en analyse d'actes d'engagement. " +
+          "Identifie le montant global des travaux HT et réponds uniquement en JSON " +
+          'au format {"amount": 123456.78}',
+      },
+      { role: "user", content: truncated },
+    ],
+    response_format: { type: "json_object" },
+  });
+  const content = chat.choices[0].message.content ?? "{}";
+  try {
+    const amount = JSON.parse(content).amount as number;
+    return Number(amount);
+  } catch {
+    console.error("Erreur de parsing JSON", content);
+    return undefined;
+  }
+}

--- a/src/lib/OpenAI/index.ts
+++ b/src/lib/OpenAI/index.ts
@@ -6,3 +6,4 @@ export type { MethodologyScore } from "./extractMethodologyScores";
 export { default as extractConsultationInfo } from "./extractConsultationInfo";
 export type { ConsultationInfo } from "./extractConsultationInfo";
 export { default as extractMissions } from "./extractMissions";
+export { default as extractWorksAmount } from "./extractWorksAmount";

--- a/src/pages/MarketDocs.tsx
+++ b/src/pages/MarketDocs.tsx
@@ -3,7 +3,11 @@ import { useProjectStore } from "../store/useProjectStore";
 import { useOpenAIKeyStore } from "../store/useOpenAIKeyStore";
 import { extractPdfText } from "../lib/pdf";
 import { extractDocxText } from "../lib/docx";
-import { extractMethodologyScores, extractMissions } from "../lib/OpenAI";
+import {
+  extractMethodologyScores,
+  extractMissions,
+  extractWorksAmount,
+} from "../lib/OpenAI";
 import type { MarketDocument, MarketDocumentType } from "../types/project";
 
 function MarketDocs() {
@@ -37,7 +41,8 @@ function MarketDocs() {
     if (docType === "AE" && apiKey) {
       try {
         const missions = await extractMissions(text, apiKey);
-        updateCurrentProject({ missions });
+        const worksAmount = await extractWorksAmount(text, apiKey);
+        updateCurrentProject({ missions, worksAmount });
       } catch (err) {
         console.error(err);
       }
@@ -94,6 +99,19 @@ function MarketDocs() {
           </li>
         ))}
       </ul>
+      <div className="space-y-1">
+        <label className="font-semibold">Montant global des travaux (€)</label>
+        <input
+          type="number"
+          className="w-full border p-2"
+          value={currentProject.worksAmount ?? ""}
+          onChange={(e) =>
+            updateCurrentProject({
+              worksAmount: e.target.value ? Number(e.target.value) : undefined,
+            })
+          }
+        />
+      </div>
     </div>
   );
 }

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -28,6 +28,7 @@ function Projects() {
       id: crypto.randomUUID(),
       consultationTitle,
       submissionDeadline,
+      worksAmount: undefined,
       creationDate: new Date().toISOString(),
       lastUpdateDate: new Date().toISOString(),
     });

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -40,6 +40,8 @@ export interface Project {
   consultationTitle: string;
   /** Date limite de remise des offres au format ISO */
   submissionDeadline: string;
+  /** Montant global des travaux en euros HT */
+  worksAmount?: number;
   creationDate: string;
   lastUpdateDate: string;
   groupType?: "solidaire" | "conjoint";


### PR DESCRIPTION
## Summary
- add `worksAmount` to Project type
- extract global works amount from the AE with OpenAI
- store `worksAmount` when creating projects
- allow user to edit the amount in market documents page

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_688a4620b0d48325ac24852cb02f60a1