### PR TITLE
Improve file input styling

### DIFF
--- a/src/components/MobilizedPeopleList.tsx
+++ b/src/components/MobilizedPeopleList.tsx
@@ -95,6 +95,7 @@ function MobilizedPeopleList({
                 onChange={(e) =>
                   onFileChange(company.id, person.id, e.target.files?.[0])
                 }
+                className="rounded border border-gray-300 bg-gray-100 p-2"
               />
               <button
                 type="button"

--- a/src/pages/Groupement.tsx
+++ b/src/pages/Groupement.tsx
@@ -275,6 +275,7 @@ function Groupement() {
                   onChange={(e) =>
                     handlePresentationChange(company.id, e.target.files?.[0])
                   }
+                  className="rounded border border-gray-300 bg-gray-100 p-2"
                 />
                 <button
                   type="button"

--- a/src/pages/MarketDocs.tsx
+++ b/src/pages/MarketDocs.tsx
@@ -73,7 +73,12 @@ function MarketDocs() {
           <option value="AE">AE</option>
           <option value="AUTRE">Autre</option>
         </select>
-        <input type="file" accept=".pdf,.docx" onChange={handleFileChange} />
+        <input
+          type="file"
+          accept=".pdf,.docx"
+          onChange={handleFileChange}
+          className="rounded border border-gray-300 bg-gray-100 p-2"
+        />
       </div>
       <ul className="space-y-2">
         {docs.map((doc) => (

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -97,7 +97,7 @@ function Projects() {
           type="file"
           accept=".pdf,.docx"
           onChange={handleRCFileChange}
-          className="w-full"
+          className="w-full rounded border border-gray-300 bg-gray-100 p-2"
         />
         <input
           className="w-full border p-2"
@@ -137,7 +137,7 @@ function Projects() {
         type="file"
         accept=".json,.zip"
         onChange={handleImport}
-        className="w-full"
+        className="w-full rounded border border-gray-300 bg-gray-100 p-2"
       />
       <ul className="space-y-2">
         {projects.map((project) => (


### PR DESCRIPTION
## Summary
- add Tailwind border and gray background to all HTML file inputs

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_688a4b736c1483258d89e6ec5e8147b8