### PR TITLE
Add AI estimation for missions

### DIFF
--- a/src/lib/OpenAI/estimateMissionDays.ts
+++ b/src/lib/OpenAI/estimateMissionDays.ts
@@ -1,0 +1,56 @@
+import createClient from "./client";
+import type {
+  ParticipatingCompany,
+  MobilizedPerson,
+} from "../../types/project";
+
+export interface MissionEstimation {
+  name: string;
+  justification: string;
+  people: { name: string; days: number }[];
+}
+
+export default async function estimateMissionDays(
+  missions: string[],
+  companies: ParticipatingCompany[],
+  worksAmount: number | undefined,
+  apiKey: string,
+): Promise<MissionEstimation[]> {
+  const openai = createClient(apiKey);
+  const missionList = missions.map((m) => `- ${m}`).join("\n");
+  const peopleList = companies
+    .map((c) => {
+      const ppl = c.mobilizedPeople ?? [];
+      if (!ppl.length) return "";
+      const rows = ppl
+        .map((p: MobilizedPerson) => `- ${p.name} (${c.name})`)
+        .join("\n");
+      return rows;
+    })
+    .filter(Boolean)
+    .join("\n");
+  const userContent = `Missions:\n${missionList}\n\nPersonnes mobilisées:\n${peopleList}\n\nMontant global des travaux HT: ${
+    worksAmount ?? "non précisé"
+  }\n\nRéponds uniquement en JSON au format {"missions":[{"name":"DIA","justification":"texte court","people":[{"name":"Nom","days":10}]}]}`;
+
+  const chat = await openai.chat.completions.create({
+    model: "gpt-4o",
+    messages: [
+      {
+        role: "system",
+        content:
+          "Tu es un assistant expert en planification de missions de maîtrise d'oeuvre. Propose une répartition du nombre de jours par mission et par personne mobilisée avec une justification courte.",
+      },
+      { role: "user", content: userContent },
+    ],
+    response_format: { type: "json_object" },
+  });
+
+  const content = chat.choices[0].message.content ?? "{}";
+  try {
+    return JSON.parse(content).missions as MissionEstimation[];
+  } catch {
+    console.error("Erreur de parsing JSON", content);
+    return [];
+  }
+}

--- a/src/lib/OpenAI/index.ts
+++ b/src/lib/OpenAI/index.ts
@@ -6,3 +6,5 @@ export type { MethodologyScore } from "./extractMethodologyScores";
 export { default as extractConsultationInfo } from "./extractConsultationInfo";
 export type { ConsultationInfo } from "./extractConsultationInfo";
 export { default as extractMissions } from "./extractMissions";
+export { default as estimateMissionDays } from "./estimateMissionDays";
+export type { MissionEstimation } from "./estimateMissionDays";

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -34,6 +34,8 @@ export type MissionDays = Record<
   Record<string, Record<string, number>>
 >;
 
+export type MissionJustifications = Record<string, string>;
+
 export interface Project {
   id: string;
   /** Titre de la consultation extrait du RC */
@@ -58,4 +60,6 @@ export interface Project {
   missions?: string[];
   /** Jours alloués par mission, entreprise et personne mobilisée */
   missionDays?: MissionDays;
+  /** Justification du chiffrage par mission */
+  missionJustifications?: MissionJustifications;
 }


### PR DESCRIPTION
## Summary
- enable OpenAI estimate to fill mission days with explanations
- store mission justifications
- allow estimation via button on Missions page

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_688a500fab3483258206c9e05d1cb0ec