### PR TITLE
Add AI planning page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Projects from "./pages/Projects";
 import Groupement from "./pages/Groupement";
 import MarketDocs from "./pages/MarketDocs";
 import Missions from "./pages/Missions";
+import Planning from "./pages/Planning";
 import Memoire from "./pages/Memoire";
 import Notation from "./pages/Notation";
 import Settings from "./pages/Settings";
@@ -44,6 +45,7 @@ function App() {
             <Route path="/documents" element={<MarketDocs />} />
             <Route path="/memoire" element={<Memoire />} />
             <Route path="/missions" element={<Missions />} />
+            <Route path="/planning" element={<Planning />} />
             <Route path="/notation" element={<Notation />} />
             <Route path="/parametres" element={<Settings />} />
           </Routes>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -70,6 +70,14 @@ function Sidebar({ isOpen, onClose }: SidebarProps) {
           Missions
         </NavLink>
         <NavLink
+          to="/planning"
+          className={({ isActive }) =>
+            `mb-2 rounded px-2 py-1 ${isActive ? "bg-blue-500 text-white" : "text-blue-500"}`
+          }
+        >
+          Planning
+        </NavLink>
+        <NavLink
           to="/notation"
           className={({ isActive }) =>
             `mb-2 rounded px-2 py-1 ${isActive ? "bg-blue-500 text-white" : "text-blue-500"}`

--- a/src/lib/OpenAI/extractPlanningConstraints.ts
+++ b/src/lib/OpenAI/extractPlanningConstraints.ts
@@ -1,0 +1,21 @@
+import createClient from "./client";
+
+export default async function extractPlanningConstraints(
+  text: string,
+  apiKey: string,
+): Promise<string> {
+  const openai = createClient(apiKey);
+  const truncated = text.slice(0, 100000);
+  const chat = await openai.chat.completions.create({
+    model: "gpt-4o",
+    messages: [
+      {
+        role: "system",
+        content:
+          "Tu es un expert des marches publics. Resume en moins de 500 mots les contraintes de planning et le calendrier prevu que tu trouves dans l'acte d'engagement. Retourne uniquement le texte du resume.",
+      },
+      { role: "user", content: truncated },
+    ],
+  });
+  return chat.choices[0].message.content?.trim() ?? "";
+}

--- a/src/lib/OpenAI/generatePlanning.ts
+++ b/src/lib/OpenAI/generatePlanning.ts
@@ -1,0 +1,25 @@
+import createClient from "./client";
+
+export default async function generatePlanning(
+  missions: string[],
+  constraints: string,
+  apiKey: string,
+): Promise<string> {
+  const openai = createClient(apiKey);
+  const list = missions.map((m, i) => `${i + 1}. ${m}`).join("\n");
+  const chat = await openai.chat.completions.create({
+    model: "gpt-4o",
+    messages: [
+      {
+        role: "system",
+        content:
+          "Tu es un planificateur specialise en marche public. En te basant sur les missions et les contraintes de planning suivantes, propose un planning synthetique respectant toutes les contraintes. Repond uniquement en Markdown.",
+      },
+      {
+        role: "user",
+        content: `Contraintes :\n${constraints}\n\nMissions :\n${list}`,
+      },
+    ],
+  });
+  return chat.choices[0].message.content?.trim() ?? "";
+}

--- a/src/lib/OpenAI/index.ts
+++ b/src/lib/OpenAI/index.ts
@@ -9,3 +9,5 @@ export { default as extractMissions } from "./extractMissions";
 export { default as estimateMissionDays } from "./estimateMissionDays";
 export type { MissionDayEstimation } from "./estimateMissionDays";
 export { default as generateMemoire } from "./generateMemoire";
+export { default as extractPlanningConstraints } from "./extractPlanningConstraints";
+export { default as generatePlanning } from "./generatePlanning";

--- a/src/pages/MarketDocs.tsx
+++ b/src/pages/MarketDocs.tsx
@@ -3,7 +3,11 @@ import { useProjectStore } from "../store/useProjectStore";
 import { useOpenAIKeyStore } from "../store/useOpenAIKeyStore";
 import { extractPdfText } from "../lib/pdf";
 import { extractDocxText } from "../lib/docx";
-import { extractMethodologyScores, extractMissions } from "../lib/OpenAI";
+import {
+  extractMethodologyScores,
+  extractMissions,
+  extractPlanningConstraints,
+} from "../lib/OpenAI";
 import type { MarketDocument, MarketDocumentType } from "../types/project";
 
 function MarketDocs() {
@@ -37,7 +41,8 @@ function MarketDocs() {
     if (docType === "AE" && apiKey) {
       try {
         const missions = await extractMissions(text, apiKey);
-        updateCurrentProject({ missions });
+        const planningSummary = await extractPlanningConstraints(text, apiKey);
+        updateCurrentProject({ missions, planningSummary });
       } catch (err) {
         console.error(err);
       }

--- a/src/pages/Planning.tsx
+++ b/src/pages/Planning.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { useProjectStore } from "../store/useProjectStore";
+import { useOpenAIKeyStore } from "../store/useOpenAIKeyStore";
+import { generatePlanning } from "../lib/OpenAI";
+
+function Planning() {
+  const { currentProject, updateCurrentProject } = useProjectStore();
+  const { apiKey } = useOpenAIKeyStore();
+  const [generating, setGenerating] = useState(false);
+
+  if (!currentProject) {
+    return (
+      <div className="p-4 text-red-500">Veuillez sélectionner un projet.</div>
+    );
+  }
+
+  const missions = currentProject.missions ?? [];
+
+  const handleGenerate = async (): Promise<void> => {
+    if (!missions.length) {
+      alert("Aucune mission détectée");
+      return;
+    }
+    const key = apiKey || import.meta.env.VITE_OPENAI_KEY;
+    if (!key) {
+      alert("Veuillez saisir votre clé OpenAI dans les paramètres.");
+      return;
+    }
+    setGenerating(true);
+    try {
+      const text = await generatePlanning(
+        missions,
+        currentProject.planningSummary ?? "",
+        key,
+      );
+      updateCurrentProject({ planningText: text });
+    } catch (err) {
+      console.error(err);
+    }
+    setGenerating(false);
+  };
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold">Planning</h1>
+      <textarea
+        className="w-full border p-2"
+        value={currentProject.planningSummary ?? ""}
+        onChange={(e) =>
+          updateCurrentProject({ planningSummary: e.target.value })
+        }
+        placeholder="Résumé des contraintes de planning"
+      />
+      <button
+        type="button"
+        onClick={handleGenerate}
+        className="cursor-pointer rounded bg-green-500 px-4 py-2 text-white"
+      >
+        Générer Planning via IA
+      </button>
+      {generating && <div>Génération en cours...</div>}
+      {currentProject.planningText && (
+        <textarea
+          className="w-full border p-2"
+          readOnly
+          value={currentProject.planningText}
+        />
+      )}
+    </div>
+  );
+}
+
+export default Planning;

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -66,4 +66,8 @@ export interface Project {
   missionDays?: MissionDays;
   /** Justification du nombre de jours par mission, entreprise et personne */
   missionJustifications?: MissionJustifications;
+  /** Texte résumant les contraintes de planning extraites de l'AE */
+  planningSummary?: string;
+  /** Planning généré par l'IA en Markdown */
+  planningText?: string;
 }


### PR DESCRIPTION
## Summary
- analyze the Acte d'Engagement to extract planning constraints
- allow editing this summary and generate a planning using AI
- expose the new planning page in sidebar and routes

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_688a686053fc8325a9dc3c6e0870573f