### PR TITLE
Add planning chart

### DIFF
--- a/src/components/PlanningChart.tsx
+++ b/src/components/PlanningChart.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef } from "react";
+import parsePlanning from "../lib/parsePlanning";
+
+interface PlanningChartProps {
+  markdown: string;
+}
+
+function PlanningChart({ markdown }: PlanningChartProps) {
+  const ref = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    const tasks = parsePlanning(markdown);
+    const svg = ref.current;
+    if (!svg) return;
+    while (svg.firstChild) svg.removeChild(svg.firstChild);
+    if (!tasks.length) return;
+
+    const width = 600;
+    const barHeight = 24;
+    const margin = { top: 20, right: 20, bottom: 30, left: 120 };
+    const total = tasks.reduce((sum, t) => sum + t.duration, 0);
+    const height = tasks.length * barHeight + margin.top + margin.bottom;
+    svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+
+    const scale = (value: number): number => {
+      return (
+        margin.left + ((width - margin.left - margin.right) * value) / total
+      );
+    };
+
+    let start = 0;
+    tasks.forEach((task, i) => {
+      const y = margin.top + i * barHeight;
+      const end = start + task.duration;
+      const rect = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "rect",
+      );
+      rect.setAttribute("x", scale(start).toString());
+      rect.setAttribute("y", y.toString());
+      rect.setAttribute("width", (scale(end) - scale(start)).toString());
+      rect.setAttribute("height", (barHeight - 4).toString());
+      rect.setAttribute("fill", "#4ade80");
+      svg.appendChild(rect);
+
+      const text = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "text",
+      );
+      text.setAttribute("x", (scale(start) + 4).toString());
+      text.setAttribute("y", (y + (barHeight - 4) / 2).toString());
+      text.setAttribute("dominant-baseline", "middle");
+      text.textContent = task.label;
+      svg.appendChild(text);
+
+      start = end;
+    });
+
+    const axis = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    const ticks = total;
+    for (let i = 0; i <= ticks; i++) {
+      const x = scale(i);
+      const line = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "line",
+      );
+      line.setAttribute("x1", x.toString());
+      line.setAttribute("x2", x.toString());
+      line.setAttribute(
+        "y1",
+        (margin.top + tasks.length * barHeight).toString(),
+      );
+      line.setAttribute(
+        "y2",
+        (margin.top + tasks.length * barHeight + 6).toString(),
+      );
+      line.setAttribute("stroke", "black");
+      axis.appendChild(line);
+
+      const label = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "text",
+      );
+      label.setAttribute("x", x.toString());
+      label.setAttribute(
+        "y",
+        (margin.top + tasks.length * barHeight + 20).toString(),
+      );
+      label.setAttribute("text-anchor", "middle");
+      label.textContent = i.toString();
+      axis.appendChild(label);
+    }
+    svg.appendChild(axis);
+  }, [markdown]);
+
+  return <svg ref={ref} className="w-full" />;
+}
+
+export default PlanningChart;

--- a/src/lib/parsePlanning.ts
+++ b/src/lib/parsePlanning.ts
@@ -1,0 +1,31 @@
+export interface PlanningTask {
+  label: string;
+  duration: number;
+}
+
+export default function parsePlanning(markdown: string): PlanningTask[] {
+  const tasks: PlanningTask[] = [];
+  const lines = markdown.split(/\n/);
+  const tableLines = lines.filter((l) => /^\|/.test(l));
+  if (tableLines.length > 2) {
+    for (const line of tableLines.slice(2)) {
+      const cells = line.split("|").map((c) => c.trim());
+      if (cells.length >= 3) {
+        const label = cells[1];
+        const num = Number(cells[2].replace(/[^0-9]/g, ""));
+        if (label && !Number.isNaN(num)) {
+          tasks.push({ label, duration: num });
+        }
+      }
+    }
+  }
+  if (!tasks.length) {
+    for (const line of lines) {
+      const match = line.match(/^(?:\d+\.|[-*])\s*(.+?)\s+(\d+)/);
+      if (match) {
+        tasks.push({ label: match[1].trim(), duration: Number(match[2]) });
+      }
+    }
+  }
+  return tasks;
+}

--- a/src/pages/Planning.tsx
+++ b/src/pages/Planning.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useProjectStore } from "../store/useProjectStore";
 import { useOpenAIKeyStore } from "../store/useOpenAIKeyStore";
 import { generatePlanning } from "../lib/OpenAI";
+import PlanningChart from "../components/PlanningChart";
 
 function Planning() {
   const { currentProject, updateCurrentProject } = useProjectStore();
@@ -60,11 +61,14 @@ function Planning() {
       </button>
       {generating && <div>Génération en cours...</div>}
       {currentProject.planningText && (
-        <textarea
-          className="w-full border p-2"
-          readOnly
-          value={currentProject.planningText}
-        />
+        <>
+          <textarea
+            className="w-full border p-2"
+            readOnly
+            value={currentProject.planningText}
+          />
+          <PlanningChart markdown={currentProject.planningText} />
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- create parser to extract tasks and durations from planning Markdown
- render a simple SVG planning chart when a planning is generated

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_688a6c82b14c8325a298f11bd10fe03e